### PR TITLE
fix errors in versions of WoW where factions and currencies don't exist

### DIFF
--- a/core.lua
+++ b/core.lua
@@ -208,9 +208,11 @@ local function FactionsUpdate()
         -- Patch 5.0.4 Added new return value: factionID
         local name, description, standingId, bottomValue, topValue, earnedValue, atWarWith, canToggleAtWar, isHeader, isCollapsed, hasRep, isWatched, isChild, factionID = GetFactionInfo(factionIndex);
 
-        if name~=nil and factionID~=nil and GetFriendshipReputation~=nil then
+        if name~=nil and factionID~=nil then
             -- Patch 5.1.0 Added API GetFriendshipReputation
-            local friendID, friendRep, friendMaxRep, friendName, friendText, friendTexture, friendTextLevel = GetFriendshipReputation(factionID)
+            if GetFriendshipReputation~=nil then
+                local friendID, friendRep, friendMaxRep, friendName, friendText, friendTexture, friendTextLevel = GetFriendshipReputation(factionID)
+            end
 
             local standingLabel
             if isHeader == nil then

--- a/core.lua
+++ b/core.lua
@@ -208,7 +208,7 @@ local function FactionsUpdate()
         -- Patch 5.0.4 Added new return value: factionID
         local name, description, standingId, bottomValue, topValue, earnedValue, atWarWith, canToggleAtWar, isHeader, isCollapsed, hasRep, isWatched, isChild, factionID = GetFactionInfo(factionIndex);
 
-        if name~=nil and factionID~=nil then
+        if name~=nil and factionID~=nil and GetFriendshipReputation~=nil then
             -- Patch 5.1.0 Added API GetFriendshipReputation
             local friendID, friendRep, friendMaxRep, friendName, friendText, friendTexture, friendTextLevel = GetFriendshipReputation(factionID)
 
@@ -234,7 +234,7 @@ local function CurrencyUpdate()
     wipe(currencies);
 
     -- thanks to @StevieTV for wow 9.0 update
-    local limit = C_CurrencyInfo.GetCurrencyListSize();
+    local limit = C_CurrencyInfo and C_CurrencyInfo.GetCurrencyListSize() or 0;
     XMERCHANT_LOGD("[CurrencyUpdate] GetCurrencyListSize  limit: "..limit);
 
     for i=1, limit do


### PR DESCRIPTION
In WoW Classic, I was seeing errors with features that don't exist in that version of the game.  Here are fixes for those errors, which simply check whether those namespaces or functions exist before using them, so this should be version-agnostic.