### PR TITLE
prevent leak into global namespace and fix tbc

### DIFF
--- a/core.lua
+++ b/core.lua
@@ -28,7 +28,7 @@ local SKILL = L["%1$s (%2$d)"];
 local REQUIRES = L["Requires (.+)"];
 local tooltip = CreateFrame("GameTooltip", "NuuhMerchantTooltip", UIParent, "GameTooltipTemplate");
 
-function getCurrentDB()
+function xMerchant.getCurrentDB()
     return xMerchantDB and xMerchantDB.global or {}
 end
 
@@ -237,7 +237,7 @@ local function CurrencyUpdate()
     wipe(currencies);
 
     -- thanks to @StevieTV for wow 9.0 update
-    local limit = C_CurrencyInfo and C_CurrencyInfo.GetCurrencyListSize() or 0;
+    local limit = C_CurrencyInfo.GetCurrencyListSize and C_CurrencyInfo.GetCurrencyListSize() or 0;
     XMERCHANT_LOGD("[CurrencyUpdate] GetCurrencyListSize  limit: "..limit);
 
     for i=1, limit do
@@ -599,10 +599,10 @@ local function xScrollFrame_OnVerticalScroll(self, offset)
     local current_offset_n = FauxScrollFrame_GetOffset(self);
     local offset_n = (offset >= 0 and 1 or -1) * math.floor(math.abs(offset) / xMerchant.kItemButtonHeight + 0.1);
     local changed_n = offset_n - current_offset_n
-    if getCurrentDB().scroll_limit_enabled then
-        if changed_n > getCurrentDB().scroll_limit_amount or changed_n < -getCurrentDB().scroll_limit_amount then
-            changed_n = math.min(changed_n, getCurrentDB().scroll_limit_amount)
-            changed_n = math.max(changed_n, -getCurrentDB().scroll_limit_amount)
+    if xMerchant.getCurrentDB().scroll_limit_enabled then
+        if changed_n > xMerchant.getCurrentDB().scroll_limit_amount or changed_n < -xMerchant.getCurrentDB().scroll_limit_amount then
+            changed_n = math.min(changed_n, xMerchant.getCurrentDB().scroll_limit_amount)
+            changed_n = math.max(changed_n, -xMerchant.getCurrentDB().scroll_limit_amount)
             offset_n = (current_offset_n + changed_n)
             offset = (offset_n > 0.1 and (offset_n - 0.1) or 0) * xMerchant.kItemButtonHeight
         end
@@ -888,8 +888,8 @@ local function xMerchant_InitItemsButtons()
         highlight:SetTexture("Interface\\Buttons\\UI-Listbox-Highlight2");
         highlight:Hide();
 
-        local itemname_fontsize = getCurrentDB().itemname_fontsize or 15
-        local iteminfo_fontsize = getCurrentDB().iteminfo_fontsize or 12
+        local itemname_fontsize = xMerchant.getCurrentDB().itemname_fontsize or 15
+        local iteminfo_fontsize = xMerchant.getCurrentDB().iteminfo_fontsize or 12
 
         local itemname = button:CreateFontString("ARTWORK", "$parentItemName");
         button.itemname = itemname;


### PR DESCRIPTION
There's a `getCurrentDB` global function which could interact with any other addon that has a global function with the same name.  This fixes that by prepending `xMerchant.` on that symbol name.

Also, TBC Classic has an error with the currency list stuff.  This fixes that, and I've tested in TBC Classic.  It's working there now with this one-line change at line 240.